### PR TITLE
use default QoS settings for point clouds

### DIFF
--- a/zivid_camera/include/zivid_camera/zivid_camera.hpp
+++ b/zivid_camera/include/zivid_camera/zivid_camera.hpp
@@ -48,12 +48,6 @@ enum class CameraStatus
   Disconnected
 };
 
-struct ZividCameraOptions
-{
-  std::string node_name = "zivid_camera";
-  rclcpp::QoS qos_profile = rclcpp::SystemDefaultsQoS();
-};
-
 class ZividCamera : public rclcpp::Node
 {
 public:

--- a/zivid_camera/src/zivid_camera.cpp
+++ b/zivid_camera/src/zivid_camera.cpp
@@ -266,16 +266,15 @@ ZividCamera::ZividCamera(const rclcpp::NodeOptions& options) : rclcpp::Node("ziv
   load_settings_2d_from_file_service_ = create_service<zivid_interfaces::srv::LoadSettings2DFromFile>(
       "load_settings_2d_from_file", std::bind(&ZividCamera::loadSettings2DFromFileServiceHandler, this, _1, _2, _3));
 
-  auto points_xyz_publisher_qos = rclcpp::SystemDefaultsQoS();
+  rclcpp::QoS qos_default{rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default)};
+
   if (use_latched_publisher_for_points_xyz_)
   {
-    points_xyz_publisher_qos.durability(rclcpp::DurabilityPolicy::TransientLocal);
+    qos_default.durability(rclcpp::DurabilityPolicy::TransientLocal);
   }
-  points_xyz_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("points/xyz", points_xyz_publisher_qos);
-
-  auto points_xyzrgba_publisher_qos = rclcpp::SystemDefaultsQoS();
+  points_xyz_publisher_ = create_publisher<sensor_msgs::msg::PointCloud2>("points/xyz", qos_default);
   points_xyzrgba_publisher_ =
-      create_publisher<sensor_msgs::msg::PointCloud2>("points/xyzrgba", points_xyzrgba_publisher_qos);
+      create_publisher<sensor_msgs::msg::PointCloud2>("points/xyzrgba", qos_default);
 
   RCLCPP_INFO_STREAM(this->get_logger(), camera_);
   if (!file_camera_mode_)

--- a/zivid_samples/setup.cfg
+++ b/zivid_samples/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/zivid_samples
+script_dir=$base/lib/zivid_samples
 [install]
-install-scripts=$base/lib/zivid_samples
+install_scripts=$base/lib/zivid_samples


### PR DESCRIPTION
From the main commit message:
```
The QoS preset 'rmw_qos_profile_system_default' uses a depth of 0. This
prevents the use of intraprocess communication and causes the exception:
"intraprocess communication is not allowed with a zero qos history depth".

The preset 'rmw_qos_profile_default' (as used for images) uses a depth of
10, hence allowing to set the node parameter 'use_intra_process_comms'.
```

In summary, this PR is required to use the Zivid node with `use_intra_process_comms` in the default configuration. I added some cleanup commits to remove unused code and silence a deprecation warning in the Python install script. While users of the node could change those QoS settings themselves to allow `use_intra_process_comms`, it is much more convenient if the node runs as expected by default.