### PR TITLE
fix point cloud colour channel order

### DIFF
--- a/zivid_camera/include/zivid_camera/zivid_camera.hpp
+++ b/zivid_camera/include/zivid_camera/zivid_camera.hpp
@@ -48,12 +48,6 @@ enum class CameraStatus
   Disconnected
 };
 
-struct ZividCameraOptions
-{
-  std::string node_name = "zivid_camera";
-  rclcpp::QoS qos_profile = rclcpp::SystemDefaultsQoS();
-};
-
 class ZividCamera : public rclcpp::Node
 {
 public:

--- a/zivid_camera/src/zivid_camera.cpp
+++ b/zivid_camera/src/zivid_camera.cpp
@@ -354,7 +354,7 @@ void ZividCamera::publishPointCloudXYZ(const std_msgs::msg::Header& header, cons
 
 void ZividCamera::publishPointCloudXYZRGBA(const std_msgs::msg::Header& header, const Zivid::PointCloud& point_cloud)
 {
-  using ZividDataType = Zivid::PointXYZColorRGBA;
+  using ZividDataType = Zivid::PointXYZColorBGRA;
   auto msg = std::make_unique<sensor_msgs::msg::PointCloud2>();
   zivid_conversions::fillCommonMsgFields(*msg, header, point_cloud.width(), point_cloud.height());
   msg->fields.reserve(4);

--- a/zivid_samples/setup.cfg
+++ b/zivid_samples/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/zivid_samples
+script_dir=$base/lib/zivid_samples
 [install]
-install-scripts=$base/lib/zivid_samples
+install_scripts=$base/lib/zivid_samples


### PR DESCRIPTION
From the main commit:
```
The ROS ecosystem (RViz, etc.) expects the packaged 32bit colour in the
point cloud to be in the order B-G-R. This fixes an issue with the
visualisation of the coloured point cloud in RViz.
```

You can easily reproduce the issue by subscribing to `points/xyzrgba` in RViz via the `rviz_default_plugins/PointCloud2` Display plugin and pointing the camera at something coloured blue. RViz will visualise the blue point cloud points with an orange/red colour. With this PR, the colours are correctly visualised in RViz.

See also the [relevant section in the ROS1 node](https://github.com/zivid/zivid-ros/blob/v2.3.0/zivid_camera/src/zivid_camera.cpp#L552-L559).